### PR TITLE
Base Julia dockerfile

### DIFF
--- a/base/base-julia.Dockerfile
+++ b/base/base-julia.Dockerfile
@@ -1,0 +1,92 @@
+# Stage 1: Build stage
+ARG BUILD_FROM
+FROM $BUILD_FROM AS build
+
+# Install apt packages
+COPY apt-packages.txt /tmp/
+RUN apt update && \
+    xargs -a /tmp/apt-packages.txt apt install -y && \
+    rm /tmp/apt-packages.txt && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Julia (source: official Julia image 1.12.0-trixie)
+# https://github.com/docker-library/julia/blob/30e953f8abfa024651984120929c403b7cdf5a9a/1.12/trixie/Dockerfile)
+
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+
+# https://julialang.org/juliareleases.asc
+# Julia (Binary signing key) <buildbot@julialang.org>
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+
+# https://julialang.org/downloads/
+ENV JULIA_VERSION 1.12.0
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.12.0.sha256
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') \
+			url='https://julialang-s3.julialang.org/bin/linux/x64/1.12/julia-1.12.0-linux-x86_64.tar.gz'; \
+			sha256='6f87b8fcf5ef6a7371e8c79d948aedfa0ba28ce44447c446d7d82e70f0158da8'; \
+			;; \
+		'arm64') \
+			url='https://julialang-s3.julialang.org/bin/linux/aarch64/1.12/julia-1.12.0-linux-aarch64.tar.gz'; \
+			sha256='0fb44de10c3a9da719b4962c2158fe4484d98377e521318b692e91a1bea5716b'; \
+			;; \
+		'i386') \
+			url='https://julialang-s3.julialang.org/bin/linux/x86/1.12/julia-1.12.0-linux-i686.tar.gz'; \
+			sha256='bef313ad70b3b3131a879118a388a878cb6e0aceab018f8dbf01de247d31f705'; \
+			;; \
+		*) \
+			echo >&2 "error: current architecture ($arch) does not have a corresponding Julia binary release"; \
+			exit 1; \
+			;; \
+	esac; \
+	\
+	curl -fL -o julia.tar.gz.asc "$url.asc"; \
+	curl -fL -o julia.tar.gz "$url"; \
+	\
+	echo "$sha256 *julia.tar.gz" | sha256sum --strict --check -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+
+# smoke test
+	julia --version
+
+# Install Julia packages
+ENV JULIA_DEPOT_PATH=/opt/julia_depot
+RUN julia -e 'using Pkg; Pkg.add(["JSON","HTTP"])'
+
+# Install Python packages
+COPY requirements.txt /tmp/
+RUN update-ca-certificates \
+    && pip install --no-cache-dir --requirement /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+# Metadata
+LABEL description="Docker image for FaaSr-py (with julia)"

--- a/base/base-julia.Dockerfile
+++ b/base/base-julia.Dockerfile
@@ -13,9 +13,12 @@ RUN apt update && \
 # Install Julia (source: official Julia image 1.12.0-trixie)
 # https://github.com/docker-library/julia/blob/30e953f8abfa024651984120929c403b7cdf5a9a/1.12/trixie/Dockerfile)
 
-
 ENV JULIA_PATH /usr/local/julia
 ENV PATH $JULIA_PATH/bin:$PATH
+
+# Setup julia depot in tmp for AWS Lambda
+RUN mkdir -p /tmp/julia_depot
+ENV JULIA_DEPOT_PATH=/tmp/julia_depot
 
 # https://julialang.org/juliareleases.asc
 # Julia (Binary signing key) <buildbot@julialang.org>
@@ -79,7 +82,7 @@ RUN set -eux; \
 	julia --version
 
 # Install Julia packages
-ENV JULIA_DEPOT_PATH=/opt/julia_depot
+
 RUN julia -e 'using Pkg; Pkg.add(["JSON","HTTP"])'
 
 # Install Python packages

--- a/base/base-julia.Dockerfile
+++ b/base/base-julia.Dockerfile
@@ -13,12 +13,9 @@ RUN apt update && \
 # Install Julia (source: official Julia image 1.12.0-trixie)
 # https://github.com/docker-library/julia/blob/30e953f8abfa024651984120929c403b7cdf5a9a/1.12/trixie/Dockerfile)
 
+
 ENV JULIA_PATH /usr/local/julia
 ENV PATH $JULIA_PATH/bin:$PATH
-
-# Setup julia depot in tmp for AWS Lambda
-RUN mkdir -p /tmp/julia_depot
-ENV JULIA_DEPOT_PATH=/tmp/julia_depot
 
 # https://julialang.org/juliareleases.asc
 # Julia (Binary signing key) <buildbot@julialang.org>
@@ -82,8 +79,8 @@ RUN set -eux; \
 	julia --version
 
 # Install Julia packages
-
-RUN julia -e 'using Pkg; Pkg.add(["JSON","HTTP"])'
+ENV JULIA_DEPOT_PATH=/opt/julia_depot
+RUN julia -e 'using Pkg; Pkg.add(["JSON","HTTP","CSV","DataFrames"])'
 
 # Install Python packages
 COPY requirements.txt /tmp/

--- a/base/base-julia.Dockerfile
+++ b/base/base-julia.Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && \
 # https://github.com/docker-library/julia/blob/30e953f8abfa024651984120929c403b7cdf5a9a/1.12/trixie/Dockerfile)
 
 
-ENV JULIA_PATH /usr/local/julia
+ENV JULIA_PATH /tmp/julia
 ENV PATH $JULIA_PATH/bin:$PATH
 
 # https://julialang.org/juliareleases.asc
@@ -79,7 +79,7 @@ RUN set -eux; \
 	julia --version
 
 # Install Julia packages
-ENV JULIA_DEPOT_PATH=/opt/julia_depot
+ENV JULIA_DEPOT_PATH $JULIA_PATH/packages
 RUN julia -e 'using Pkg; Pkg.add(["JSON","HTTP","CSV","DataFrames"])'
 
 # Install Python packages


### PR DESCRIPTION
Adds a new base image with Julia and Python installed. Platform-specific images can be built on top in the same manner as with the base or base-r images.