### PR TITLE
Change pip package location

### DIFF
--- a/base/base.Dockerfile
+++ b/base/base.Dockerfile
@@ -2,6 +2,9 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM AS build
 
+RUN mkdir /tmp/packages
+ENV PYTHONPATH=/tmp/packages
+
 # Install apt packages
 COPY apt-packages.txt /tmp/
 RUN apt update && \


### PR DESCRIPTION
This PR combines with #18 on Faasr-Backend, changing the PYTHONPATH variable to source packages from /tmp/packages. This enables package installation on AWS Lambda.