### PR TITLE
Add build workflow for the Julia base image

### DIFF
--- a/.github/workflows/build_base_julia.yml
+++ b/.github/workflows/build_base_julia.yml
@@ -1,0 +1,46 @@
+name: julia-base -> DockerHub
+  # This action builds a base Julia image for use in FaaSr
+  # It requires you to have your DOCKERHUB_USERNAME and DOCKERHUB_TOKEN configured as secrets
+  # The base image is built from a Python image input as BUILD_FROM (Julia is installed on top;
+  # Python is retained so the FaaSr-py entry point can run the Julia user function)
+  # Once built, the base image will be pushed to DOCKERHUB_USERNAME/BASE_NAME:FAASR_VERSION
+on:
+  workflow_dispatch:
+    inputs:
+      # BUILD_FROM is the full user/name:tag of the Python image to build this base from
+      BUILD_FROM:
+        description: 'user/name:tag to build this base from'
+        required: true
+        default: 'python:3.13'
+      # BASE_NAME is the name to be used for this base FaaSr image
+      # Examples: base-tidyverse, base-geospatial, base-flare
+      BASE_NAME:
+        description: 'name to be used for this base FaaSr image'
+        required: true
+        default: 'base-julia'
+      # FAASR_VERSION is the FaaSr-py version tag to be used for this base FaaSr image
+      FAASR_VERSION:
+        description: 'FaaSr version tag'
+        required: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build base FaaSr Docker image
+        run: |
+          cd base
+          docker build -f base-julia.Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.inputs.BASE_NAME }}:${{ github.event.inputs.FAASR_VERSION }} --build-arg BUILD_FROM=${{ github.event.inputs.BUILD_FROM }} .
+      - name: Push base FaaSr Docker image
+        run: |
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.inputs.BASE_NAME }}:${{ github.event.inputs.FAASR_VERSION }}


### PR DESCRIPTION
The `base-julia.Dockerfile` was added (in #7) but has no corresponding build workflow, so there is no automated way to build and publish the `base-julia` image. R has `build_base_rocker.yml` and Python has `build_base.yml`; this adds `build_base_julia.yml` to match.

The workflow mirrors `build_base.yml`: a `workflow_dispatch` with `BUILD_FROM` (default `python:3.13`), `BASE_NAME` (default `base-julia`), and `FAASR_VERSION` inputs; it builds `base-julia.Dockerfile` and pushes to `DOCKERHUB_USERNAME/BASE_NAME:FAASR_VERSION`.

No change is needed to the platform build (`build_github-actions.yml`) — it is generic and produces a `github-actions-julia` image simply by passing the `base-julia` image as `BASE_IMAGE`.

Tested locally:
- `base-julia` builds from `python:3.13` (Julia 1.12.0 + JSON/HTTP/CSV/DataFrames + Python 3.13)
- the generic `github-actions.Dockerfile` builds a platform image from it against `FaaSr-py@2.1.0`
- the resulting image loads the Julia packages, and the installed FaaSr-py includes the Julia client stubs and the `Type: "Julia"` executor dispatch
