### PR TITLE
base-julia: add OrdinaryDiffEq for differential-equation workflows

### DIFF
--- a/base/base-julia.Dockerfile
+++ b/base/base-julia.Dockerfile
@@ -80,7 +80,7 @@ RUN set -eux; \
 
 # Install Julia packages
 ENV JULIA_DEPOT_PATH $JULIA_PATH/packages
-RUN julia -e 'using Pkg; Pkg.add(["JSON","HTTP","CSV","DataFrames"])'
+RUN julia -e 'using Pkg; Pkg.add(["JSON","HTTP","CSV","DataFrames","OrdinaryDiffEq"])'
 
 # Install Python packages
 COPY requirements.txt /tmp/


### PR DESCRIPTION
Adds `OrdinaryDiffEq` to the `base-julia` image's baked Julia packages, so Julia functions can integrate differential equations with the standard solver stack (`ODEProblem` + `solve(prob, Tsit5())`, etc.).

FaaSr has no runtime Julia-dependency mechanism (unlike Python's `PyPIPackageDownloads` and R's `FunctionCRANPackage`), so a Julia package must be present in the container image; `OrdinaryDiffEq` is a large package whose runtime precompilation is impractical inside an action. Baking it in precompiles it once at build time.

**Change:** one line in `base/base-julia.Dockerfile` —

```
- Pkg.add(["JSON","HTTP","CSV","DataFrames"])
+ Pkg.add(["JSON","HTTP","CSV","DataFrames","OrdinaryDiffEq"])
```

**Validation:** built the base image (and the `github-actions-julia` platform image on top of it) from this change and ran an SIR ODE workflow end-to-end — `OrdinaryDiffEq` installs, precompiles, and solves correctly on Julia 1.12.

**Note:** `OrdinaryDiffEq` pulls ~137 dependencies (plus MKL artifacts), so the base image grows by roughly 1-2 GB and the build takes longer. This is the tradeoff of paying the precompile cost once at build time rather than at every invocation.

**Pairs with** the `julia_sir` example in FaaSr-Functions (PR #11), which uses this solver; that example needs the official `github-actions-julia:latest` to be rebuilt from this updated base.
